### PR TITLE
DB-1218 - remove *.so file extension from PostgreSQL extensions

### DIFF
--- a/currency.control
+++ b/currency.control
@@ -1,5 +1,5 @@
 # currency extension
 comment = 'Custom PostgreSQL currency type'
-default_version = '0.0.4'
+default_version = '0.0.5'
 relocatable = true
 requires = 'plpgsql'

--- a/sql/currency--0.0.4--0.0.5.sql
+++ b/sql/currency--0.0.4--0.0.5.sql
@@ -1,0 +1,64 @@
+CREATE FUNCTION supported_currencies()
+    RETURNS SETOF currency
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_in(cstring)
+    RETURNS currency
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_out(currency)
+    RETURNS cstring
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_recv(internal)
+    RETURNS currency
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_send(currency)
+    RETURNS bytea
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_lt(currency, currency)
+    RETURNS BOOL
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_le(currency, currency)
+    RETURNS BOOL
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_eq(currency, currency)
+    RETURNS BOOL
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_neq(currency, currency)
+    RETURNS BOOL
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_ge(currency, currency)
+    RETURNS BOOL
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_gt(currency, currency)
+    RETURNS BOOL
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION hash_currency(currency)
+    RETURNS integer
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION currency_cmp(currency, currency)
+    RETURNS int4
+    AS '$libdir/currency'
+    LANGUAGE C IMMUTABLE STRICT;

--- a/sql/currency--0.0.5.sql
+++ b/sql/currency--0.0.5.sql
@@ -1,3 +1,4 @@
+
 CREATE TYPE currency;
 
 CREATE FUNCTION supported_currencies()


### PR DESCRIPTION
Please see [DB-1218](https://adjustcom.atlassian.net/browse/DB-1218) for context

[DB-1218]: https://adjustcom.atlassian.net/browse/DB-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ