### PR TITLE
DB-1218 | fix upgrade path file with CREATE OR REPLACE statement

### DIFF
--- a/sql/currency--0.0.4--0.0.5.sql
+++ b/sql/currency--0.0.4--0.0.5.sql
@@ -1,64 +1,64 @@
-CREATE FUNCTION supported_currencies()
+CREATE OR REPLACE FUNCTION supported_currencies()
     RETURNS SETOF currency
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_in(cstring)
+CREATE OR REPLACE FUNCTION currency_in(cstring)
     RETURNS currency
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_out(currency)
+CREATE OR REPLACE FUNCTION currency_out(currency)
     RETURNS cstring
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_recv(internal)
+CREATE OR REPLACE FUNCTION currency_recv(internal)
     RETURNS currency
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_send(currency)
+CREATE OR REPLACE FUNCTION currency_send(currency)
     RETURNS bytea
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_lt(currency, currency)
+CREATE OR REPLACE FUNCTION currency_lt(currency, currency)
     RETURNS BOOL
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_le(currency, currency)
+CREATE OR REPLACE FUNCTION currency_le(currency, currency)
     RETURNS BOOL
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_eq(currency, currency)
+CREATE OR REPLACE FUNCTION currency_eq(currency, currency)
     RETURNS BOOL
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_neq(currency, currency)
+CREATE OR REPLACE FUNCTION currency_neq(currency, currency)
     RETURNS BOOL
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_ge(currency, currency)
+CREATE OR REPLACE FUNCTION currency_ge(currency, currency)
     RETURNS BOOL
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_gt(currency, currency)
+CREATE OR REPLACE FUNCTION currency_gt(currency, currency)
     RETURNS BOOL
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION hash_currency(currency)
+CREATE OR REPLACE FUNCTION hash_currency(currency)
     RETURNS integer
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION currency_cmp(currency, currency)
+CREATE OR REPLACE FUNCTION currency_cmp(currency, currency)
     RETURNS int4
     AS '$libdir/currency'
     LANGUAGE C IMMUTABLE STRICT;


### PR DESCRIPTION
We removed `.so` file extension in the `pg-currency` extension with this [PR](https://github.com/adjust/pg-currency/pull/19). 
However update should have contained `CREATE OR REPLACE FUNCTION` statement rather than only `CREATE FUNCTON`.
This PR fixes the error mentioned. After approval I will deploy-update the extension on `backend` hosts.

Deployment should be done using `infrastructure` repository. 